### PR TITLE
🐛Fix: Project setup on MacOS

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -35,9 +35,10 @@ const defineConfig = (): ExpoConfig => ({
   //   },
   // },
   extra: {
-    eas: {
-      projectId: 'a5b98934-bf53-4573-ba91-972c22a6759a',
-    },
+    // this is commented out so you don't have to log in to run expo start locally
+    // eas: {
+    //   projectId: 'a5b98934-bf53-4573-ba91-972c22a6759a',
+    // },
     clerkPublishableKey: process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY,
     expoPublicClerkPublishableKey:
       process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 
     "dev"             : "turbo dev --parallel --filter=!@acme/expo",
     "db:studio"       : "pnpm db:prisma && cd packages/prisma && pnpm dotenv -e ../../.env prisma studio",
-    "db:prisma"       : "cd packages/prisma && pnpm prisma generate && pnpm dotenv -e ../../.env prisma studio",
+    "db:prisma"       : "cd packages/prisma && pnpm prisma generate && pnpm dotenv -e ../../.env prisma db push",
     
     "format"          : "turbo format --continue -- --cache --cache-location node_modules/.cache/.prettiercache",
     "format:fix"      : "turbo format --continue -- --write --cache --cache-location node_modules/.cache/.prettiercache",


### PR DESCRIPTION
Fixing the package.json to the proper prisma command and commenting out the project id so we don't have to log in to eas when running expo start locally. 