### PR TITLE
Remove nav bar from screens

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -66,16 +66,17 @@ export default function RootLayout() {
             <Stack
               screenOptions={
                 {
+                  headerShown: false,
                   // headerStyle: {
-                  //   backgroundColor: '#f472b6',
-                  // },
-                  // contentStyle: {
-                  //   backgroundColor: colorScheme == 'dark' ? '#09090B' : '#FFFFFF',
-                  // },
-                }
-              }
+                    //   backgroundColor: '#f472b6',
+                    // },
+                    // contentStyle: {
+                      //   backgroundColor: colorScheme == 'dark' ? '#09090B' : '#FFFFFF',
+                      // },
+                    }
+                  }
             />
-            <StatusBar />
+          <StatusBar style='light'/>
           </GlobalContextProvider>
         </BottomSheetModalProvider>
       </ClerkProvider>

--- a/apps/expo/src/app/nav/index.tsx
+++ b/apps/expo/src/app/nav/index.tsx
@@ -2,6 +2,7 @@ import type { Route } from 'expo-router'
 import React from 'react'
 import { Button, FlatList, StyleSheet, View } from 'react-native'
 import { router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 const styles = StyleSheet.create({
   container: {
@@ -12,7 +13,7 @@ const styles = StyleSheet.create({
 
 const Nav = () => {
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <FlatList
         data={[
           // add your component routes here
@@ -25,7 +26,7 @@ const Nav = () => {
           <Button title={item.key} onPress={() => router.push(item.route as Route<string>)} />
         )}
       />
-    </View>
+    </SafeAreaView>
   )
 }
 

--- a/apps/expo/src/app/notif/misc/index.tsx
+++ b/apps/expo/src/app/notif/misc/index.tsx
@@ -6,17 +6,18 @@ import { router } from 'expo-router'
 import MiscNotifs from '~/components/notif/miscNotifs/miscNotifs';
 import DmNotifs from '~/components/notif/dmNotifs';
 import GcNotifs from '~/components/notif/gcNotifs';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export type notifsType = "misc" | "dm" | "gc"
 
-export default function MiscNotifScreen() {
+export default function NotifScreen() {
   
   const [visibleNotifs, setVisibleNotifs] = useState<notifsType>("misc");
   
   return (
-    <View style={{backgroundColor: "#1C1B1B", flex: 1}}>
+    <SafeAreaView style={{backgroundColor: "#1C1B1B", flex: 1}}>
       {/*header w/ back and new message buttons*/}
-      <View className="flex flex-row justify-between pt-5 px-5">
+      <View className="flex flex-row justify-between px-5">
         <Ionicons onPress={() => router.back()} name="chevron-back" size={24} color="#CACACA" />
         <Text style={{color: "#CACACA", fontSize: 20}}>Notifications</Text>
         <MaterialCommunityIcons name="message-plus-outline" size={24} color="#CACACA" />
@@ -49,6 +50,6 @@ export default function MiscNotifScreen() {
           {visibleNotifs == "gc" && <GcNotifs />}
         </View>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 }


### PR DESCRIPTION
# What type of PR is this? (Check all that apply)

- [ ] ✨**feature**: Introduces completely new code or new features.
- [x] 🐛**fix**: Implements changes that fix a bug. Ideally, reference an issue if present.
- [ ] ♻️**refactor**: Includes any code-related change that is neither a fix nor a feature.
- [ ] ✅**build**: Encompasses all changes related to the build of the software, including changes to dependencies or the addition of new ones.
- [ ] ⚡️**test**: Pertains to all changes regarding tests, whether adding new tests or modifying existing ones.
- [ ] 🚰**ci**: Involves all changes related to the configuration of continuous integration, such as GitHub Actions or other CI systems.
- [ ] 📚**docs**: Includes all changes to documentation, such as README files, or any other documentation present in the repository.
- [x] 🗑️**chore**: Captures all changes to the repository that do not fit into the above categories.

# Description

Main change was removing the nav bar from the top of the screen. This was a one-liner change done on _layout.tsx. Other small changes were done too, namely:
- Rename component `MiscNotifScreen` -> `NotifScreen` since we will be using a single component for all of the notifs (including DM and GC). I will reform the file structure in a later PR. 
- Make the `StatusBar` style `light` since our app has a dark color theme (this changes the color of the time/battery info/etc to be white text instead of black)
- Change `View` to `SafeAreaView` for both the `NotifScreen` component and the `Nav` component to ensure compatibility now that we have removed the top default nav bar

# Tests

How was this tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual tests
- [ ] Tests were NOT needed
- [ ] Other (explain below)

Explanation:

# Documentation

- [ ] Added to README.me
- [ ] Seperate document
- [x] NO documentation needed
**_Read notes at end_**

# [Optional] Screenshots
![Screenshot 2024-03-17 at 5 23 18 PM](https://github.com/UNLV-CS472-672/2024-S-GROUP3-Barbell/assets/85365584/1eaa0285-06c7-465d-92cc-80b036e947c6)
![Screenshot 2024-03-17 at 5 23 29 PM](https://github.com/UNLV-CS472-672/2024-S-GROUP3-Barbell/assets/85365584/be5389e2-8c33-4e59-b5d2-c0995f783285)
![Screenshot 2024-03-17 at 5 26 23 PM](https://github.com/UNLV-CS472-672/2024-S-GROUP3-Barbell/assets/85365584/01d83b61-fd3f-4a65-ac8c-76ea6f59482e)


# [Optional] Are there any post-deployment tasks we need to perform?

# Additional notes
- **I don't think we should use a `SafeAreaView` on the auth page.** It looks fine without it since the patter spans across the whole screen.
- When creating screens, implement a back button functionality if necessary.  