### PR TITLE
Backend -- Prisma Schema Spotify Update

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -99,6 +99,7 @@ model User {
   notifications Notification[] @relation("NotificationReceiver")
   sentMessages  Notification[] @relation("NotificationSender")
   chats         Chat[]
+  spotify       SpotifyData?
 }
 
 // ******************************************************************************************
@@ -265,4 +266,33 @@ model Message {
   chat      Chat     @relation(fields: [chatId], references: [id])
   chatId    Int
   senderId  Int
+}
+
+// ******************************************************************************************
+// * spotifyData
+// * id : Auto incremented unique identifier
+// * albumImageURL: URL of album's image to display on frontend. Can be null 
+// * albumName: String name of the album in case we'd like to display it.
+// * artist: Name of song's artist. Can be null.
+// * isPlaying: Boolean to see if song is currently playing. Goes for all songs. Not null.
+// * songURL: URL of song playing. Can be null 
+// * title: Title of currently playing song. Can be null.
+// * timePlayed: Progress into current song. Can be null.
+// * timeTotal: Total length of song. Can be null.
+// * artistURL: URL of song's artist. Can be null.
+// * userID: Foreign key to user
+// ******************************************************************************************
+model SpotifyData {
+  id        Int   @id @default(autoincrement())
+  albumImageURL String?
+  albumName String?
+  artist    String?
+  isPlaying Boolean   @default(false)
+  songURL   String?
+  title     String?
+  timePlayed  Int?
+  timeTotal Int?
+  artistURL String?
+  user      User @relation(fields: [userID], references: [id])
+  userID    Int @unique
 }


### PR DESCRIPTION
# What type of PR is this? (Check all that apply)

- [x] ✨**feature**: Introduces completely new code or new features.
- [ ] 🐛**fix**: Implements changes that fix a bug. Ideally, reference an issue if present.
- [ ] ♻️**refactor**: Includes any code-related change that is neither a fix nor a feature.
- [ ] ✅**build**: Encompasses all changes related to the build of the software, including changes to dependencies or the addition of new ones.
- [ ] ⚡️**test**: Pertains to all changes regarding tests, whether adding new tests or modifying existing ones.
- [ ] 🚰**ci**: Involves all changes related to the configuration of continuous integration, such as GitHub Actions or other CI systems.
- [ ] 📚**docs**: Includes all changes to documentation, such as README files, or any other documentation present in the repository.
- [ ] 🗑️**chore**: Captures all changes to the repository that do not fit into the above categories.

# Description

Updated prisma schema to include a new model for data (named SpotifyData) we get through the Spotify API regarding a user's currently playing track. Also updated user model to include a new field (one-to-one) for said data, optional as we should wait to see if the user will approve using Spotify on their account (future issue). 

# Tests

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual tests
- [ ] Tests were NOT needed
- [ ] Other (explain below)

Explanation:
I tested it locally by just creating a few new rows and adding relevant data fields making sure of a few things:
   1) Each user could exist without a spotify field, but not vice versa (success).
   2) All fields must be initialized to null outside of isPlaying (used for frontend display logic) (success).

# Documentation

- [ ] Added to README.me
- [x] Seperate document
- [ ] NO documentation needed

Link to external documentation: https://developer.spotify.com/documentation/web-api/reference/get-the-users-currently-playing-track

(Above link has information on what kind of data can be found within each .json response through the Spotify API and was used to figure out what types to make each relevant field, as well as which ones to allow as optional fields or not).

# [Optional] Screenshots

# [Optional] Are there any post-deployment tasks we need to perform?

# Additional notes

Most of this PR was just spent discussing with team on how to setup new schema to make sure there weren't any issues that would cause other APIs or mock data to stop working, as well as what to include locally vs on the database itself. Below are additional resources used to help guide the direction of the final implemented model as we got familiar with a new 3rd party API (there is still more to be done as we further expand on how much Spotify integration we desire in the future):

https://medium.com/@alagappan.dev/create-a-now-playing-widget-using-the-spotify-web-api-in-react-a6cb564ed923
https://developer.spotify.com/documentation/web-api/reference/get-the-users-currently-playing-track
https://github.com/JoeKarlsson/react-spotify-player