### PR TITLE
ReadByUserIds functionality: new API, component modification

### DIFF
--- a/apps/expo/src/components/notif/Conversation.tsx
+++ b/apps/expo/src/components/notif/Conversation.tsx
@@ -25,7 +25,7 @@ export default function Conversation({ messageContent, chatId, createdAt, chatNa
   const handleRead = () => {
     if (!isRead) {
       markAsRead.mutate({ chatId: chatId, type: type, userId: userData.id })
-      readBy.push(userData.id)
+      readBy.push(userData.id) // this is so it will immediately reflect that the changes so it doesn't have to wait for API call again
     }
   }
 

--- a/apps/expo/src/components/notif/Conversation.tsx
+++ b/apps/expo/src/components/notif/Conversation.tsx
@@ -1,47 +1,62 @@
-import { TouchableOpacity, View, Text } from "react-native"
-import TimeAgo from "~/components/timeAgo/TimeAgo"
+import { Text, TouchableOpacity, View } from 'react-native'
+import { Link } from 'expo-router'
+
 import { MaterialCommunityIcons } from '@expo/vector-icons'
-import { useGlobalContext } from "~/context/global-context"
-import { Link } from "expo-router"
 import { ChatType } from '@prisma/client'
 
+import TimeAgo from '~/components/timeAgo/TimeAgo'
+import { useGlobalContext } from '~/context/global-context'
+import { api } from '~/utils/api'
+
 export interface ConversationProps {
-  chatId: number,
-  messageContent: string,
-  createdAt: Date,
-  chatName: string,
-  readBy: number[],
-  type: ChatType,
+  chatId: number
+  messageContent: string
+  createdAt: Date
+  chatName: string
+  readBy: number[]
+  type: ChatType
 }
 
-export default function Conversation({messageContent, chatId, createdAt, chatName, readBy, type}: ConversationProps) {
-
-  const { userData } = useGlobalContext();
+export default function Conversation({ messageContent, chatId, createdAt, chatName, readBy, type }: ConversationProps) {
+  const { userData } = useGlobalContext()
   const isRead: boolean = readBy.includes(userData.id)
-  
+  const markAsRead = api.notif.markChatAsReadByChatIdAndUserIdAndChatType.useMutation()
+
+  const handleRead = () => {
+    if (!isRead) {
+      markAsRead.mutate({ chatId: chatId, type: type, userId: userData.id })
+      readBy.push(userData.id)
+    }
+  }
+
   return (
     <View>
-      <Link href={{pathname: "/messages/", params: {chatId, chatName, type}}} asChild={true}>
-        <TouchableOpacity>
-          <View className="flex flex-row ml-3 mr-3 mt-4">
+      <Link href={{ pathname: '/messages/', params: { chatId, chatName, type } }} asChild={true}>
+        <TouchableOpacity onPress={handleRead}>
+          <View className="ml-3 mr-3 mt-4 flex flex-row">
             {/*photo, use icon for now, use profile photo in the future*/}
             <View className="mr-2">
               <MaterialCommunityIcons name="face-man-profile" size={56} color="#CACACA" />
             </View>
-            <View className="flex flex-col flex-1">
+            <View className="flex flex-1 flex-col">
               {/*sender name*/}
-              <Text className="mr-2 mb-2" style={{color: isRead ? "#A4A4A4" : "#FFFFFF", fontWeight: isRead ? "normal" : "bold"}}>
+              <Text
+                className="mb-2 mr-2"
+                style={{ color: isRead ? '#A4A4A4' : '#FFFFFF', fontWeight: isRead ? 'normal' : 'bold' }}
+              >
                 {chatName}
               </Text>
               {/*message content*/}
-              <Text numberOfLines={1} className="mr-2" style={{color: isRead ? "#A4A4A4" : "#FFFFFF"}}>{messageContent}</Text>
+              <Text numberOfLines={1} className="mr-2" style={{ color: isRead ? '#A4A4A4' : '#FFFFFF' }}>
+                {messageContent}
+              </Text>
               <TimeAgo createdAt={createdAt} />
             </View>
           </View>
         </TouchableOpacity>
       </Link>
       {/*thin line between notifications*/}
-      <View className="ml-3 mr-3" style={{borderBottomWidth: 1, borderBottomColor: "#737272"}}/>
+      <View className="ml-3 mr-3" style={{ borderBottomWidth: 1, borderBottomColor: '#737272' }} />
     </View>
   )
 }

--- a/packages/api/src/router/notif.ts
+++ b/packages/api/src/router/notif.ts
@@ -8,7 +8,7 @@ export const notifRouter = createTRPCRouter({
    *  @remarks
    *  This returns all of the messages in order from oldest to newest within any chat type
    *
-   *  @param  id - the id of the direct message chat
+   *  @param  id - the id of the chat
    *  @param  type - the chat type (DIRECT or GROUP)
    *  @returns an array of message objects
    */
@@ -38,6 +38,33 @@ export const notifRouter = createTRPCRouter({
         },
         orderBy: {
           createdAt: 'asc',
+        },
+      })
+    }),
+
+  /**
+   *  @remarks
+   *  Adds current user to readByUserIds field in DB
+   *
+   *  @param  chatId - the id of the chat
+   *  @param  userId - the id of the logged in user
+   *  @param  type - the chat type (DIRECT or GROUP)
+   *  @returns an array of message objects
+   */
+  markChatAsReadByChatIdAndUserIdAndChatType: publicProcedure
+    .input(z.object({ chatId: z.number().int(), userId: z.number().int(), type: z.nativeEnum(ChatType) }))
+    .mutation(async ({ ctx, input }) => {
+      const { prisma } = ctx
+
+      return prisma.chat.update({
+        where: {
+          id: input.chatId,
+          type: input.type,
+        },
+        data: {
+          readByUserIds: {
+            push: input.userId,
+          },
         },
       })
     }),


### PR DESCRIPTION
# What type of PR is this? (Check all that apply)

- [x] ✨**feature**: Introduces completely new code or new features.
- [x] 🐛**fix**: Implements changes that fix a bug. Ideally, reference an issue if present.
- [ ] ♻️**refactor**: Includes any code-related change that is neither a fix nor a feature.
- [ ] ✅**build**: Encompasses all changes related to the build of the software, including changes to dependencies or the addition of new ones.
- [ ] ⚡️**test**: Pertains to all changes regarding tests, whether adding new tests or modifying existing ones.
- [ ] 🚰**ci**: Involves all changes related to the configuration of continuous integration, such as GitHub Actions or other CI systems.
- [ ] 📚**docs**: Includes all changes to documentation, such as README files, or any other documentation present in the repository.
- [ ] 🗑️**chore**: Captures all changes to the repository that do not fit into the above categories.

# Description

- New API
  - `markChatAsReadByChatIdAndUserIdAndChatType` 
    - Takes ChatID, UserID, and ChatType as params, pushes logged in user's ID into readByUserIds array in DB
- Modified `Conversation` component to support this API and feature
  - If the conversation is not read, onPress => push logged in user's ID into DB, push same ID into local list to immediately reflect style change
    - If we didn't push into local list, the style would not immediately change and we would need to wait for another API call
  - Reformatted with Prettier

# Tests

How was this tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual tests
- [ ] Tests were NOT needed
- [ ] Other (explain below)

More testing when I learn how to do TRPC unit testing

# Screenshots

https://github.com/UNLV-CS472-672/2024-S-GROUP3-Barbell/assets/85365584/11b00527-15aa-4a5e-9e6b-420bbad811a1

**UserID 9 has been pushed to DB**
![Screenshot 2024-04-01 at 3 10 16 PM](https://github.com/UNLV-CS472-672/2024-S-GROUP3-Barbell/assets/85365584/3e10b72e-37ed-4b21-8a9b-55beb5f84c1a)

# Documentation

- [ ] Added to README.me
- [ ] Seperate document
- [x] NO documentation needed